### PR TITLE
Increase distance between sprite images by ten seconds

### DIFF
--- a/src/BitmovinSpriteLambda/index.js
+++ b/src/BitmovinSpriteLambda/index.js
@@ -3,7 +3,7 @@ const createSprite = (bitcodin, jobId) => {
     "jobId": parseInt(jobId),
     "height": 120,
     "width": 160,
-    "distance": 5,
+    "distance": 15,
     "async": true
   }
   return bitcodin.sprite.create(spriteConfig)


### PR DESCRIPTION
Sprite creation requires an argument, distance.  It represents the distance between screenshot thumbnails.  Currently, distance is at five seconds.  For long videos, this creates pretty big sprite files.  I believe this is causing the sprite lambda to time out for long videos.  This change increases the distance between thumbnails.  The sprite scrubber won't be quite as accurate, but it should be accurate enough.  I'm hoping this change allows the lambda function to process hour plus videos without timing out in the future.
This wiki page has more on the issue: https://execonline.atlassian.net/wiki/spaces/~jcosta/pages/677609504/Bitmovin+Video+Reprocessing+-+sprite+lambda+failures